### PR TITLE
Signing transaction triggered by event. Confirmation popup [ch1093][ch1094]

### DIFF
--- a/core/webpack.base.js
+++ b/core/webpack.base.js
@@ -9,6 +9,7 @@ module.exports = {
   entry: {
     popup: resolve('./popup'),
     background: resolve('./backend'),
+    content: resolve('./content'),
   },
   output: {
     path: path.join(__dirname, '..', 'build'),

--- a/core/webpack.dev.js
+++ b/core/webpack.dev.js
@@ -12,7 +12,7 @@ module.exports = merge(baseWebpack, {
   },
   devtool: '#cheap-module-eval-source-map',
   plugins: [
-    htmlPage('popup', 'popup', ['popup']),
+    htmlPage('Clove sign Plugin', 'popup', ['popup']),
     htmlPage('background', 'background', ['background']),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({

--- a/core/webpack.prod.js
+++ b/core/webpack.prod.js
@@ -13,7 +13,7 @@ module.exports = merge(baseWebpack, {
     rules: styleLoaders({ extract: true, sourceMap: true })
   },
   plugins: [
-    htmlPage('popup', 'popup', ['manifest', 'vendor', 'popup']),
+    htmlPage('Clove sign Plugin', 'popup', ['manifest', 'vendor', 'popup']),
     htmlPage('background', 'background', ['manifest', 'vendor', 'background']),
     new CleanWebpackPlugin(['build/*.*']),
     new webpack.NoEmitOnErrorsPlugin(),

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,4 +1,49 @@
 /* global window */
 import keyStorage from '../utils/key_storage';
+import ethNetworks from '../utils/ethereum_networks';
+import { stripHexPrefix } from '../utils/sign';
 
 window.keyStorage = keyStorage;
+
+function normalizeAddress(address, networkSymbol) {
+  if (ethNetworks.includes(networkSymbol)) {
+    return stripHexPrefix(address).toLowerCase();
+  }
+
+  return address;
+}
+
+let signData = {};
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'sign') {
+    const { network, rawTx } = message;
+    let { address } = message;
+
+    if (ethNetworks.includes(network)) {
+      address = normalizeAddress(address, network);
+    }
+
+    try {
+      window.keyStorage.getPrivateKey(network, address);
+    } catch (e) {
+      sendResponse({ error: e.message });
+      return;
+    }
+
+    signData = {
+      address,
+      network,
+      rawTx,
+      tabId: sender.tab.id,
+    };
+
+    window.open('popup.html#confirm', 'confirmation_popup', 'width=620,height=500,status=no,scrollbars=yes,resizable=yes');
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'popup-ready') {
+    sendResponse({ signData });
+  }
+});

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,0 +1,17 @@
+document.addEventListener('signTx', (event) => {
+  const signData = event.detail;
+  signData.type = 'sign';
+  chrome.runtime.sendMessage(signData, (response) => {
+    if (response) {
+      if (response.error) {
+        document.dispatchEvent(new CustomEvent('signedTx', { detail: response }));
+      }
+    }
+  });
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'signedTx') {
+    document.dispatchEvent(new CustomEvent('signedTx', { detail: message }));
+  }
+});

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -22,5 +22,11 @@ module.exports = {
   background: {
     page: 'pages/background.html',
   },
+  content_scripts: [{
+    js: ['js/content.js'],
+    run_at: 'document_end',
+    matches: ['<all_urls>'],
+    all_frames: true,
+  }],
   content_security_policy: "script-src 'self' 'unsafe-eval'; object-src 'self'",
 };

--- a/src/popup/components/confirm.vue
+++ b/src/popup/components/confirm.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <h2>Confirm signing transaction</h2>
+    <el-form :model="signData" >
+      <p class="input-description">Unsigned transaction</p>
+      <el-form-item prop="rawTx">
+        <el-input
+          type="textarea"
+          class="long-input"
+          :autosize="{ minRows: 3 }"
+          :readonly="true"
+          v-model="signData.rawTx"
+        />
+      </el-form-item>
+      <el-button
+        type="primary"
+        class="submit-button"
+        :disabled="isButtonDisabled"
+        @click="confirm">
+        Confirm
+      </el-button>
+    </el-form>
+  </div>
+</template>
+<script>
+import sign from '../../utils/sign';
+
+export default {
+  props: ['storage'],
+  data() {
+    return {
+      signData: {
+        rawTx: '',
+      },
+    };
+  },
+  created() {
+    chrome.runtime.sendMessage({ type: 'popup-ready' }, (response) => {
+      if (response) {
+        this.signData = response.signData;
+      }
+    });
+  },
+  computed: {
+    isButtonDisabled() {
+      return !this.signData.rawTx;
+    },
+  },
+  methods: {
+    confirm() {
+      const { network, address } = this.signData;
+      let signedTx = '';
+      let errorMsg = '';
+
+      try {
+        const key = this.storage.getPrivateKey(network, address);
+        signedTx = sign.signTx(
+          this.signData.rawTx,
+          key,
+          network,
+        );
+      } catch (e) {
+        errorMsg = e.message;
+        if (errorMsg === 'Invalid hex string') {
+          errorMsg = 'Invalid transaction';
+        }
+      }
+
+      let response;
+      const type = 'signedTx';
+      if (errorMsg) {
+        response = { type, error: errorMsg };
+      } else {
+        response = { type, signedTx };
+      }
+      chrome.tabs.sendMessage(this.signData.tabId, response);
+      window.close();
+    },
+  },
+};
+</script>
+<style>
+.submit-button {
+  margin-top: 30px;
+}
+</style>

--- a/src/popup/root.vue
+++ b/src/popup/root.vue
@@ -5,7 +5,7 @@
         <div class="header">Clove sign Plugin</div>
       </div>
     </div>
-    <steps :step="step"/>
+    <steps v-if="currentView!=='confirm'" :step="step"/>
     <component
       :is="currentView"
       :storage="keyStorage"
@@ -16,6 +16,7 @@
   </el-container>
 </template>
 <script>
+import confirm from './components/confirm';
 import select from './components/selectKey';
 import steps from './components/steps';
 import unlock from './components/unlock';
@@ -44,6 +45,9 @@ export default {
     } catch (e) {
       this.currentView = 'unlock';
     }
+    if (window.location.hash === '#confirm') {
+      this.currentView = 'confirm';
+    }
   },
   methods: {
     switchView(value) {
@@ -52,6 +56,7 @@ export default {
   },
   components: {
     'select-key': select,
+    confirm,
     unlock,
     steps,
     'manage-keys': manageKeys,

--- a/src/utils/ethereum_networks.js
+++ b/src/utils/ethereum_networks.js
@@ -1,0 +1,9 @@
+module.exports = [
+  'ETH',
+  'ETH-TESTNET',
+  'EGEM',
+  'ELLA',
+  'ELLA-TESTNET',
+  'EXP',
+  'MUSIC',
+];

--- a/src/utils/key_storage.js
+++ b/src/utils/key_storage.js
@@ -1,6 +1,7 @@
 /* global localStorage */
 const ethUtil = require('ethereumjs-util');
-const networks = require('./bitcoin_networks');
+const btcNetworks = require('./bitcoin_networks');
+const ethNetworks = require('./ethereum_networks');
 const nodeCryptoJs = require('node-cryptojs-aes');
 const sign = require('./sign');
 
@@ -57,14 +58,14 @@ exports.addKey = (networkSymbol, privateKey) => {
   let address;
   let key;
 
-  if (networkSymbol.startsWith('ETH')) {
+  if (ethNetworks.includes(networkSymbol)) {
     key = sign.getHexBuffer(privateKey);
     if (key.length === 0) {
       throw new Error('Invalid private key');
     }
     address = ethUtil.privateToAddress(key).toString('hex');
-  } else if (networkSymbol in networks) {
-    key = sign.getBitcoinKey(privateKey, networks[networkSymbol]);
+  } else if (networkSymbol in btcNetworks) {
+    key = sign.getBitcoinKey(privateKey, btcNetworks[networkSymbol]);
     address = key.getAddress();
   } else {
     throw new Error(`${networkSymbol} network is not supported`);
@@ -114,9 +115,4 @@ exports.getAvailableKeys = () => {
   }, {});
 };
 
-exports.getSupportedNetworks = () => {
-  const btcNetworks = Object.keys(networks);
-  const ethNetworks = ['ETH', 'ETH-TESTNET'];
-
-  return btcNetworks.concat(ethNetworks).sort();
-};
+exports.getSupportedNetworks = () => Object.keys(btcNetworks).concat(ethNetworks).sort();

--- a/src/utils/sign.js
+++ b/src/utils/sign.js
@@ -1,6 +1,7 @@
 const bitcoin = require('bitcoinjs-lib');
 const EthereumTx = require('ethereumjs-tx');
-const networks = require('./bitcoin_networks');
+const btcNetworks = require('./bitcoin_networks');
+const ethNetworks = require('./ethereum_networks');
 
 // eslint-disable-next-line arrow-body-style
 exports.stripHexPrefix = (hexString) => {
@@ -98,12 +99,12 @@ exports.signBitcoinTx = (rawTransaction = '', privateKey = '', network) => {
 };
 
 exports.signTx = (rawTransaction = '', privateKey = '', networkSymbol = '') => {
-  if (networkSymbol.startsWith('ETH')) {
+  if (ethNetworks.includes(networkSymbol)) {
     return exports.signEthereumTx(rawTransaction, privateKey);
   }
 
-  if (networkSymbol in networks) {
-    return exports.signBitcoinTx(rawTransaction, privateKey, networks[networkSymbol]);
+  if (networkSymbol in btcNetworks) {
+    return exports.signBitcoinTx(rawTransaction, privateKey, btcNetworks[networkSymbol]);
   }
 
   throw new Error(`${networkSymbol} network is not supported`);


### PR DESCRIPTION
Signing transaction can be triggered by the custom `signTx` event with the following details: `network, address, rawTx`
```
document.dispatchEvent(new CustomEvent('signTx', {
    detail: {
        network: 'ETH-TESTNET',
        address: '999F348959E611F1E9eab2927c21E88E48e6Ef45',
        rawTx: '0xf86b8201...00000000000000000de0b6b3a7640000808080',
    },
}));
```
Confirmation popup is displayed:
![clove sign plugin_001](https://user-images.githubusercontent.com/2880324/46028634-6c371280-c0f1-11e8-896a-c250f2ca2edc.png)
After user confirms, signed transaction is returned in the custom `signedTx` event as `signedTx`
```
document.addEventListener('signedTx', (event) => {
    console.log(event.detail.signedTx);
});
```